### PR TITLE
Add spell checking GitHub Actions workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,15 @@
+name: CodeSpell
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          ignore_words_file: .codespellignore

--- a/lib/ast_to_prism/parser.rb
+++ b/lib/ast_to_prism/parser.rb
@@ -129,7 +129,7 @@ module AstToPrism
       end
     end
 
-    # TODO: Implment this method
+    # TODO: Implement this method
     def convert_block_parameters(nd_args)
       return nil if nd_args.nil?
     end

--- a/lib/ast_to_prism/parser.rb
+++ b/lib/ast_to_prism/parser.rb
@@ -549,7 +549,7 @@ module AstToPrism
       when :ENSURE
         nd_head, nd_ensr = node.children
 
-        # TODO: Change original NODE strucutre
+        # TODO: Change original NODE structure
         if nd_head.type == :RESCUE
           res_nd_head, res_nd_resq, res_nd_else = nd_head.children
 

--- a/lib/ast_to_prism/parser.rb
+++ b/lib/ast_to_prism/parser.rb
@@ -527,7 +527,7 @@ module AstToPrism
           exceptions = []
         end
 
-        # TODO: Change orignal node structures and extract ERRINFO info
+        # TODO: Change original node structures and extract ERRINFO info
         if errinfo_assign?(nd_body) # `rescue Err => e` or not
           reference = convert_errinfo_assignment(nd_body.children[0])
           statements = convert_stmts(nd_body, 1..-1)


### PR DESCRIPTION
This PR adds spell checking GitHub Actions workflow and fixes typos.
Follow up: https://github.com/ruby/lrama/pull/120

```
❯ codespell .      
./lib/ast_to_prism/parser.rb:132: Implment ==> Implement
./lib/ast_to_prism/parser.rb:530: orignal ==> original
./lib/ast_to_prism/parser.rb:552: strucutre ==> structure
```